### PR TITLE
fix: return topmost sized item when sampling the wallpaper

### DIFF
--- a/1-common/components/LiquidGlass.qml
+++ b/1-common/components/LiquidGlass.qml
@@ -78,16 +78,21 @@ Item {
     function isLoader(n) {
         return n && n.sourceComponent !== undefined && n.item !== undefined
     }
+    // Pick the topmost sized item. ShaderEffectSource captures the whole
+    // subtree, so descending into children is only needed when the outer
+    // wrapper has no size yet (e.g. a Loader still resolving). Drilling
+    // past a sized parent caused us to land on hidden iChannel Images
+    // inside shader-wallpaper plugins (online.knowmad.shaderwallpaper).
     function findRenderableSource(node) {
         if (!node) return null
         if (isLoader(node)) return findRenderableSource(node.item)
+        if (node.width > 0 && node.height > 0) return node
         if (node.children && node.children.length > 0) {
             for (var i = 0; i < node.children.length; i++) {
                 const inner = findRenderableSource(node.children[i])
                 if (inner) return inner
             }
         }
-        if (node.width > 0 && node.height > 0) return node
         return null
     }
 


### PR DESCRIPTION
`findRenderableSource()` descended into children before considering the node itself, so for shader-wallpaper plugins (whose root WallpaperItem wraps a ShaderEffect that holds hidden iChannel `Image` items) we landed on the iChannel input texture instead of the rendered shader. The widget then refracted the iChannel image — visibly wrong when the shader output and the iChannel texture differ.

ShaderEffectSource captures the whole subtree, so the topmost sized item is always a correct source. Only fall back to descending into children when the outer wrapper has no size yet (e.g. an unresolved Loader).