### PR TITLE
fix(music): make album art refresh pause/play a configurable toggle

### DIFF
--- a/packages/music/contents/config/main.xml
+++ b/packages/music/contents/config/main.xml
@@ -63,5 +63,8 @@
         <entry name="lyricsFontSizeTall" type="Int">
             <default>55</default>
         </entry>
+        <entry name="artRefreshEnabled" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/packages/music/contents/ui/config/ConfigLyrics.qml
+++ b/packages/music/contents/ui/config/ConfigLyrics.qml
@@ -12,6 +12,7 @@ ColumnLayout {
     property alias cfg_lyricsFontSizeWide: wideFontSpin.value
     property alias cfg_lyricsFontSizeTall: tallFontSpin.value
     property alias cfg_lyricsBlur: lyricsBlurCheck.checked
+    property alias cfg_artRefreshEnabled: artRefreshCheck.checked
 
     Kirigami.FormLayout {
         Layout.fillWidth: true
@@ -59,6 +60,12 @@ ColumnLayout {
             id: lyricsBlurCheck
             Kirigami.FormData.label: i18n("Blur upcoming lines:")
             text: i18n("Blur upcoming lyrics lines (disable on slow hardware)")
+        }
+
+        CheckBox {
+            id: artRefreshCheck
+            Kirigami.FormData.label: i18n("Pause on track change:")
+            text: i18n("Briefly pause/resume to refresh album art (causes playback hiccups)")
         }
 
     }

--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -219,6 +219,7 @@ PlasmoidItem {
     }
 
     function _scheduleArtRefresh() {
+        if (!plasmoid.configuration.artRefreshEnabled) return
         artRefreshTimer.stop()
         artResumeTimer.stop()
         if (root.isPlaying) artRefreshTimer.start()


### PR DESCRIPTION
The music widget briefly pauses and resumes playback on every track change to force MPRIS players to re-emit album art metadata. This causes an audible ~80ms playback hiccup that affects all MPRIS players on the system (MPD, Tauon, etc.).

## Changes
- Added `artRefreshEnabled` config entry (`main.xml`) defaulting to `false`
- Added "Pause on track change" checkbox in widget settings → Lyrics tab (`ConfigLyrics.qml`)
- Gated the pause/resume art-refresh hack behind the toggle (`main.qml`)

The default is **off**, so users won't experience the hiccup unless they explicitly enable it.

edit: ai sloppy disclosure