### PR TITLE
fix(music): apply LRC offset tags and LRCLIB API offset to synced lyrics

### DIFF
--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -115,7 +115,7 @@ PlasmoidItem {
                     var resp = JSON.parse(xhr.responseText)
                     var synced = resp.syncedLyrics || ""
                     root._plainLyrics = resp.plainLyrics || ""
-                    root._syncedLyrics = synced !== "" ? root._parseLrc(synced) : []
+                    root._syncedLyrics = synced !== "" ? root._parseLrc(synced, (resp.offset || 0) * 1000) : []
                     root._lyricsState = 2
                     root._lyricsFailCount = 0
                     _lyricsRetryTimer.stop()
@@ -140,15 +140,23 @@ PlasmoidItem {
         xhr.send()
     }
 
-    function _parseLrc(lrcContent) {
+    function _parseLrc(lrcContent, apiOffsetMs) {
         var lines = lrcContent.split("\n")
         var result = []
         var re = /\[(\d{2}):(\d{2})[.:](\d{2})\](.*)/
+        var offsetRe = /\[offset:([+-]?\d+)\]/i
+        var lrcOffsetMs = 0
         for (var i = 0; i < lines.length; i++) {
+            var om = offsetRe.exec(lines[i])
+            if (om) {
+                lrcOffsetMs += parseInt(om[1])
+                continue
+            }
             var m = re.exec(lines[i])
             if (m) {
                 result.push({
-                    timestamp: parseInt(m[1]) * 60000 + parseInt(m[2]) * 1000 + parseInt(m[3]) * 10,
+                    timestamp: parseInt(m[1]) * 60000 + parseInt(m[2]) * 1000 + parseInt(m[3]) * 10
+                               + lrcOffsetMs + (apiOffsetMs || 0),
                     text: m[4].trim()
                 })
             }


### PR DESCRIPTION
LRCLIB's API returns an `offset` field (seconds) alongside `syncedLyrics`, and the LRC content itself may contain `[offset:±ms]` tags. Neither were being parsed or applied, causing synced lyrics to be out of sync for tracks with non-zero offsets.

## Changes
- Parse `[offset:±ms]` tags from LRC content in `_parseLrc()`
- Read `resp.offset` from LRCLIB API response (convert seconds → ms)
- Apply both offsets cumulatively to all parsed timestamp entries

Only affects `main.qml` — one file, +11/−3 lines.