### PR TITLE
fix(music): re-sample album art colors on every track change

### DIFF
--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -199,6 +199,7 @@ PlasmoidItem {
         root._lastPosTick = 0
         root._lastSampledUrl = ""
         _scheduleArtRefresh()
+        _resampleTimer.restart()
         root._syncedLyrics = []
         root._plainLyrics = ""
         root._lyricsState = 0
@@ -206,6 +207,15 @@ PlasmoidItem {
         root._lyricsFailCount = 0
         _lyricsRetryTimer.stop()
         _lyricsFetchTimer.restart()
+    }
+    Timer {
+        id: _resampleTimer
+        interval: 350
+        repeat: false
+        onTriggered: {
+            if (root.albumArt !== "" && root.albumArt !== root._lastSampledUrl)
+                sampleCanvas.requestPaint()
+        }
     }
     onIsPlayingChanged: {
         root.position = mpris2Model.currentPlayer?.position ?? 0
@@ -343,6 +353,7 @@ PlasmoidItem {
         onImageLoaded: {
             if (root.albumArt !== "" && root.albumArt !== root._lastSampledUrl) {
                 root._lastSampledUrl = root.albumArt
+                _resampleTimer.stop()
                 requestPaint()
             }
         }


### PR DESCRIPTION
Canvas.onImageLoaded only fires when Qt loads a new image from disk. Previously-seen album art URLs are served from the QML image cache, skipping the callback and leaving background colors stuck from the previous track.

## Reproduction
1. Play Song A (Album X art) → correct gradient colors
2. Play Song B (Album Y art) → correct gradient colors  
3. Go back to Song A → colors stay from Song B

## Fix
Add a `_resampleTimer` (350ms after track change) as a backup: if `onImageLoaded` never fires (cached image or same art URL), the timer forces a `requestPaint()`. `onImageLoaded` stops the timer to avoid double-paint for genuinely new images.

Only affects `main.qml` — +11 lines.