### PR TITLE
fix(music): use wall-clock time for lyrics position tracking

### DIFF
--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -79,14 +79,18 @@ PlasmoidItem {
         onTriggered: root._fetchLyrics()
     }
 
+    property real _lastPosTick: 0
+
     Timer {
         id: lyricsPositionTimer
         interval: 80
         running: root.isPlaying && root.lyricsActive && root.length > 0
         repeat: true
         onTriggered: {
-            if (root.position < root.length)
-                root.position += interval * 1000
+            var now = Date.now()
+            if (root._lastPosTick > 0)
+                root.position += (now - root._lastPosTick) * 1000
+            root._lastPosTick = now
         }
     }
 
@@ -161,6 +165,7 @@ PlasmoidItem {
         target: mpris2Model.currentPlayer
         function onPositionChanged() {
             root.position = mpris2Model.currentPlayer?.position ?? 0
+            root._lastPosTick = 0
         }
     }
 
@@ -170,8 +175,10 @@ PlasmoidItem {
         running: root.isPlaying && root.length > 0 && !lyricsPositionTimer.running
         repeat: true
         onTriggered: {
-            if (root.position < root.length)
-                root.position += interval * 1000
+            var now = Date.now()
+            if (root._lastPosTick > 0)
+                root.position += (now - root._lastPosTick) * 1000
+            root._lastPosTick = now
         }
     }
 
@@ -181,6 +188,7 @@ PlasmoidItem {
             albumArt = _noAlbumUrl
         }
         root.position = mpris2Model.currentPlayer?.position ?? 0
+        root._lastPosTick = 0
         root._lastSampledUrl = ""
         _scheduleArtRefresh()
         root._syncedLyrics = []
@@ -191,7 +199,10 @@ PlasmoidItem {
         _lyricsRetryTimer.stop()
         _lyricsFetchTimer.restart()
     }
-    onIsPlayingChanged: root.position = mpris2Model.currentPlayer?.position ?? 0
+    onIsPlayingChanged: {
+        root.position = mpris2Model.currentPlayer?.position ?? 0
+        root._lastPosTick = 0
+    }
     onLengthChanged: {
         if (length > 0 && _lyricsState === 0 && track !== "")
             _lyricsFetchTimer.restart()


### PR DESCRIPTION
The `lyricsPositionTimer` and `positionTimer` both incremented `root.position` by `interval * 1000` each tick, assuming perfect QML timer accuracy. In practice timers can fire early or late, causing the position to drift ahead of actual playback — synced lyrics advance too fast over time.

## Fix
- Replace fixed `interval * 1000` increment with `Date.now()` to measure real elapsed wall-clock time
- Add `_lastPosTick` property reset to 0 on track changes, play/pause state changes, and MPRIS Seeked signals — ensuring position resyncs from the player on every external position change

Only affects `main.qml` — +16/−5 lines.