### PR TITLE
feat(music): add player filtering and auto-hide support

### DIFF
--- a/packages/music/contents/config/config.qml
+++ b/packages/music/contents/config/config.qml
@@ -8,6 +8,11 @@ ConfigModel {
         source: "config/ConfigAppearance.qml"
     }
     ConfigCategory {
+        name: i18n("Filter")
+        icon: "view-filter"
+        source: "config/ConfigFilter.qml"
+    }
+    ConfigCategory {
         name: i18n("Lyrics")
         icon: "preferences-desktop-font"
         source: "config/ConfigLyrics.qml"

--- a/packages/music/contents/config/main.xml
+++ b/packages/music/contents/config/main.xml
@@ -66,5 +66,17 @@
         <entry name="artRefreshEnabled" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="playerFilter" type="String">
+            <default></default>
+        </entry>
+        <entry name="filterMode" type="Int">
+            <default>0</default>
+        </entry>
+        <entry name="autoHideEnabled" type="Bool">
+            <default>false</default>
+        </entry>
+        <entry name="autoHideTimeout" type="Int">
+            <default>30</default>
+        </entry>
     </group>
 </kcfg>

--- a/packages/music/contents/ui/config/ConfigFilter.qml
+++ b/packages/music/contents/ui/config/ConfigFilter.qml
@@ -1,0 +1,135 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+import org.kde.plasma.private.mpris as Mpris
+
+ColumnLayout {
+    id: root
+    spacing: Kirigami.Units.largeSpacing
+
+    property alias cfg_playerFilter: filterField.text
+    property alias cfg_filterMode: denyMode.checked
+    property alias cfg_autoHideEnabled: autoHideCheck.checked
+    property alias cfg_autoHideTimeout: autoHideSpin.value
+
+    Mpris.Mpris2Model { id: mprisModel }
+
+    property var _allowedList: {
+        var raw = cfg_playerFilter || ""
+        if (raw.trim() === "") return []
+        var parts = raw.split(",")
+        var list = []
+        for (var i = 0; i < parts.length; i++) {
+            var id = parts[i].trim()
+            if (id !== "") list.push(id)
+        }
+        return list
+    }
+
+    readonly property bool _isDenyMode: cfg_filterMode
+
+    function _isChecked(identity) {
+        for (var i = 0; i < root._allowedList.length; i++) {
+            if (root._allowedList[i] === identity) return true
+        }
+        return false
+    }
+
+    function _toggle(identity) {
+        var list = root._allowedList
+        var idx = list.indexOf(identity)
+        if (idx >= 0) list.splice(idx, 1)
+        else list.push(identity)
+        cfg_playerFilter = list.join(",")
+    }
+
+    function _reload() {
+        playerRepeater.model = 0
+        var ids = []
+        const CONTAINER_ROLE = Qt.UserRole + 1
+        for (var i = 1; i < mprisModel.rowCount(); i++) {
+            var player = mprisModel.data(mprisModel.index(i, 0), CONTAINER_ROLE)
+            if (player && player.identity) ids.push(player.identity)
+        }
+        playerRepeater.model = ids
+    }
+
+    Component.onCompleted: _reload()
+
+    TextField {
+        id: filterField
+        visible: false
+    }
+
+    Kirigami.FormLayout {
+        Layout.fillWidth: true
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Player filter")
+        }
+
+        CheckBox {
+            id: denyMode
+            Kirigami.FormData.label: i18n("Mode:")
+            text: i18n("Deny selected players (instead of allowing only selected)")
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Detected players:")
+            Button {
+                icon.name: "view-refresh"
+                text: i18n("Refresh")
+                onClicked: root._reload()
+            }
+        }
+
+        Label {
+            Layout.fillWidth: true
+            text: root._isDenyMode
+                ? i18n("Checked players will be ignored by the widget.")
+                : i18n("Only checked players are shown. When nothing is checked, all players are shown.")
+            wrapMode: Text.WordWrap
+            opacity: 0.7
+        }
+
+        ColumnLayout {
+            spacing: 0
+            Layout.fillWidth: true
+
+            Repeater {
+                id: playerRepeater
+
+                delegate: CheckBox {
+                    text: modelData
+                    checked: root._isChecked(modelData)
+                    onToggled: root._toggle(modelData)
+                    Layout.fillWidth: true
+                }
+            }
+        }
+    }
+
+    Kirigami.FormLayout {
+        Layout.fillWidth: true
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Auto-hide")
+        }
+
+        CheckBox {
+            id: autoHideCheck
+            Kirigami.FormData.label: i18n("When idle:")
+            text: i18n("Hide widget when nothing is playing")
+        }
+
+        SpinBox {
+            id: autoHideSpin
+            Kirigami.FormData.label: i18n("Timeout (seconds):")
+            enabled: autoHideCheck.checked
+            from: 5; to: 3600; stepSize: 5
+        }
+    }
+}

--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -12,6 +12,27 @@ PlasmoidItem {
     Plasmoid.backgroundHints: PlasmaCore.Types.NoBackground
     preferredRepresentation: fullRepresentation
 
+    readonly property bool _shouldShow: {
+        if (!plasmoid.configuration.autoHideEnabled) return true
+        return root.isPlaying
+    }
+
+    on_ShouldShowChanged: {
+        if (_shouldShow) {
+            root.visible = true
+            _autoHideTimer.stop()
+        } else if (plasmoid.configuration.autoHideEnabled) {
+            _autoHideTimer.restart()
+        }
+    }
+
+    Timer {
+        id: _autoHideTimer
+        interval: plasmoid.configuration.autoHideTimeout * 1000
+        repeat: false
+        onTriggered: root.visible = false
+    }
+
     MacOSColors {
         id: colors
         styleMode: plasmoid.configuration.styleMode
@@ -25,10 +46,39 @@ PlasmoidItem {
 
     Mpris.Mpris2Model { id: mpris2Model }
 
-    readonly property string track:   mpris2Model.currentPlayer?.track ?? ""
-    readonly property string artist:  mpris2Model.currentPlayer?.artist ?? ""
-    readonly property string album:   mpris2Model.currentPlayer?.album ?? ""
-    readonly property string _rawAlbumArt: mpris2Model.currentPlayer?.artUrl ?? ""
+    function _isPlayerAllowed(identity) {
+        var f = (plasmoid.configuration.playerFilter || "").toLowerCase()
+        if (f === "") return true
+        var list = f.split(",")
+        var id = (identity || "").toLowerCase()
+        var inList = false
+        for (var i = 0; i < list.length; i++) {
+            if (list[i].trim() === id) { inList = true; break }
+        }
+        return plasmoid.configuration.filterMode === 1 ? !inList : inList
+    }
+
+    property var _activePlayer: {
+        var cp = mpris2Model.currentPlayer
+        if (cp && _isPlayerAllowed(cp.identity) && (cp.track || cp.artist))
+            return cp
+        const CONTAINER_ROLE = Qt.UserRole + 1
+        for (var i = 1; i < mpris2Model.rowCount(); i++) {
+            var p = mpris2Model.data(mpris2Model.index(i, 0), CONTAINER_ROLE)
+            if (p && _isPlayerAllowed(p.identity) && (p.track || p.artist))
+                return p
+        }
+        return cp
+    }
+    readonly property bool _playerAllowed: {
+        var cp = mpris2Model.currentPlayer
+        return cp ? _isPlayerAllowed(cp.identity) : true
+    }
+
+    readonly property string track:   _activePlayer?.track ?? ""
+    readonly property string artist:  _activePlayer?.artist ?? ""
+    readonly property string album:   _activePlayer?.album ?? ""
+    readonly property string _rawAlbumArt: _activePlayer?.artUrl ?? ""
     readonly property string _noAlbumUrl: Qt.resolvedUrl("icons/no_album.png")
     property string albumArt: _noAlbumUrl
 
@@ -42,13 +92,13 @@ PlasmoidItem {
         interval: 150
         onTriggered: root.albumArt = root._rawAlbumArt
     }
-    readonly property int playbackStatus: mpris2Model.currentPlayer?.playbackStatus ?? 0
+    readonly property int playbackStatus: _activePlayer?.playbackStatus ?? 0
     readonly property bool isPlaying: playbackStatus === Mpris.PlaybackStatus.Playing
-    readonly property bool canGoPrevious: mpris2Model.currentPlayer?.canGoPrevious ?? false
-    readonly property bool canGoNext:     mpris2Model.currentPlayer?.canGoNext ?? false
-    readonly property bool canPlay:  mpris2Model.currentPlayer?.canPlay ?? false
-    readonly property bool canPause: mpris2Model.currentPlayer?.canPause ?? false
-    readonly property real length: mpris2Model.currentPlayer?.length ?? 0
+    readonly property bool canGoPrevious: _activePlayer?.canGoPrevious ?? false
+    readonly property bool canGoNext:     _activePlayer?.canGoNext ?? false
+    readonly property bool canPlay:  _activePlayer?.canPlay ?? false
+    readonly property bool canPause: _activePlayer?.canPause ?? false
+    readonly property real length: _activePlayer?.length ?? 0
 
     property real position: 0
     property bool lyricsActive: false
@@ -170,9 +220,9 @@ PlasmoidItem {
     }
 
     Connections {
-        target: mpris2Model.currentPlayer
+        target: root._activePlayer
         function onPositionChanged() {
-            root.position = mpris2Model.currentPlayer?.position ?? 0
+            if (root._activePlayer) root.position = root._activePlayer.position
             root._lastPosTick = 0
         }
     }
@@ -195,7 +245,7 @@ PlasmoidItem {
             _artDebounceTimer.stop()
             albumArt = _noAlbumUrl
         }
-        root.position = mpris2Model.currentPlayer?.position ?? 0
+        root.position = root._activePlayer?.position ?? 0
         root._lastPosTick = 0
         root._lastSampledUrl = ""
         _scheduleArtRefresh()
@@ -208,7 +258,7 @@ PlasmoidItem {
         _lyricsFetchTimer.restart()
     }
     onIsPlayingChanged: {
-        root.position = mpris2Model.currentPlayer?.position ?? 0
+        root.position = root._activePlayer?.position ?? 0
         root._lastPosTick = 0
     }
     onLengthChanged: {
@@ -221,8 +271,8 @@ PlasmoidItem {
         interval: 300
         repeat: false
         onTriggered: {
-            if (mpris2Model.currentPlayer && root.isPlaying) {
-                mpris2Model.currentPlayer.Pause()
+            if (root._activePlayer && root.isPlaying) {
+                root._activePlayer.Pause()
                 artResumeTimer.start()
             }
         }
@@ -233,7 +283,7 @@ PlasmoidItem {
         interval: 80
         repeat: false
         onTriggered: {
-            if (mpris2Model.currentPlayer) mpris2Model.currentPlayer.Play()
+            if (root._activePlayer) root._activePlayer.Play()
         }
     }
 
@@ -245,25 +295,26 @@ PlasmoidItem {
     }
 
     function togglePlaying() {
-        if (mpris2Model.currentPlayer) mpris2Model.currentPlayer.PlayPause()
+        if (!root._activePlayer) return
+        root._activePlayer.PlayPause()
     }
     function next() {
-        if (!mpris2Model.currentPlayer) return
+        if (!root._activePlayer) return
         root._flipDirection = -1
-        mpris2Model.currentPlayer.Next()
+        root._activePlayer.Next()
     }
     function previous() {
-        if (!mpris2Model.currentPlayer) return
+        if (!root._activePlayer) return
         root._flipDirection = 1
-        mpris2Model.currentPlayer.Previous()
+        root._activePlayer.Previous()
     }
     function seek(positionUs) {
-        if (mpris2Model.currentPlayer) {
-            var current = mpris2Model.currentPlayer.position ?? 0
-            var offset = positionUs - current
-            mpris2Model.currentPlayer.Seek(offset)
-            root.position = positionUs
-        }
+        if (!root._activePlayer) return
+        var currentPos = root._activePlayer.position ?? root.position
+        var offset = positionUs - currentPos
+        root._activePlayer.Seek(offset)
+        root.position = positionUs
+        root._lastPosTick = 0
     }
 
     function formatTime(us) {

--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -249,6 +249,7 @@ PlasmoidItem {
         root._lastPosTick = 0
         root._lastSampledUrl = ""
         _scheduleArtRefresh()
+        _resampleTimer.restart()
         root._syncedLyrics = []
         root._plainLyrics = ""
         root._lyricsState = 0
@@ -256,6 +257,15 @@ PlasmoidItem {
         root._lyricsFailCount = 0
         _lyricsRetryTimer.stop()
         _lyricsFetchTimer.restart()
+    }
+    Timer {
+        id: _resampleTimer
+        interval: 350
+        repeat: false
+        onTriggered: {
+            if (root.albumArt !== "" && root.albumArt !== root._lastSampledUrl)
+                sampleCanvas.requestPaint()
+        }
     }
     onIsPlayingChanged: {
         root.position = root._activePlayer?.position ?? 0
@@ -394,6 +404,7 @@ PlasmoidItem {
         onImageLoaded: {
             if (root.albumArt !== "" && root.albumArt !== root._lastSampledUrl) {
                 root._lastSampledUrl = root.albumArt
+                _resampleTimer.stop()
                 requestPaint()
             }
         }


### PR DESCRIPTION
## What this does

### Player filtering
Lets you pick which MPRIS players the widget responds to. Open the config, go to the **Filter** tab, and check/uncheck detected players. Toggle between allow mode (only checked players are shown) and deny mode (checked players are ignored). When nothing is checked, all players are shown.

### Auto-hide
When enabled, the widget hides after a configurable timeout when nothing is playing. It reappears instantly when playback resumes. This is useful for panel widgets or desktop widgets you only want to see when music is active.

### Implementation
- Adds `_activePlayer` property that resolves the current player through the filter instead of using `mpris2Model.currentPlayer` directly
- Adds `_shouldShow` + `_autoHideTimer` for idle visibility control
- New `ConfigFilter.qml` config page with player allow/deny UI and auto-hide section
- New kcfg entries: `playerFilter`, `filterMode`, `autoHideEnabled`, `autoHideTimeout`

### Files changed
- `packages/music/contents/config/config.qml` — add Filter category
- `packages/music/contents/config/main.xml` — new config entries
- `packages/music/contents/ui/config/ConfigFilter.qml` — new config page
- `packages/music/contents/ui/main.qml` — player filtering + auto-hide logic