### PR TITLE
feat: Add 24-hour option to digital clock

### DIFF
--- a/packages/clock-digital/contents/config/main.xml
+++ b/packages/clock-digital/contents/config/main.xml
@@ -42,5 +42,8 @@
         <entry name="realtimeRefraction" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="use24Hour" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/packages/clock-digital/contents/ui/config/ConfigAppearance.qml
+++ b/packages/clock-digital/contents/ui/config/ConfigAppearance.qml
@@ -1,1 +1,208 @@
-../../../../../1-common/config/ConfigAppearance.qml
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+ColumnLayout {
+    id: root
+    spacing: Kirigami.Units.largeSpacing
+
+    property alias cfg_styleMode: styleCombo.currentIndex
+    property alias cfg_appearance: appearanceCombo.currentIndex
+    property alias cfg_cornerRadius: radiusSpin.value
+    property alias cfg_roundnessX10: roundnessSpin.value
+    property alias cfg_refractThickness: thicknessSpin.value
+    property alias cfg_refractIORx100: iorSpin.value
+    property alias cfg_refractScale: scaleSpin.value
+    property alias cfg_tintAlphaPct: tintSpin.value
+    property alias cfg_chromaStrengthPct: chromaSpin.value
+    property alias cfg_specStrengthPct: specStrengthSpin.value
+    property alias cfg_blurRadiusPx: blurRadiusSpin.value
+    property alias cfg_realtimeRefraction: realtimeCheck.checked
+    property alias cfg_use24Hour: use24HourCheck.checked
+
+    function _serialize() {
+        return JSON.stringify({
+            s: styleCombo.currentIndex,
+            a: appearanceCombo.currentIndex,
+            cr: radiusSpin.value,
+            rn: roundnessSpin.value,
+            rt: thicknessSpin.value,
+            ri: iorSpin.value,
+            rs: scaleSpin.value,
+            ta: tintSpin.value,
+            ca: chromaSpin.value,
+            ss: specStrengthSpin.value,
+            br: blurRadiusSpin.value,
+            rr: realtimeCheck.checked,
+            h24: use24HourCheck.checked
+        })
+    }
+
+    function _deserialize(text) {
+        try {
+            var o = JSON.parse(text)
+            if (o.s  !== undefined) styleCombo.currentIndex      = o.s
+            if (o.a  !== undefined) appearanceCombo.currentIndex  = o.a
+            if (o.cr !== undefined) radiusSpin.value              = o.cr
+            if (o.rn !== undefined) roundnessSpin.value           = o.rn
+            if (o.rt !== undefined) thicknessSpin.value           = o.rt
+            if (o.ri !== undefined) iorSpin.value                 = o.ri
+            if (o.rs !== undefined) scaleSpin.value               = o.rs
+            if (o.ta !== undefined) tintSpin.value                = o.ta
+            if (o.ca !== undefined) chromaSpin.value              = o.ca
+            if (o.ss !== undefined) specStrengthSpin.value        = o.ss
+            if (o.br !== undefined) blurRadiusSpin.value          = o.br
+            if (o.rr !== undefined) realtimeCheck.checked         = o.rr
+            if (o.h24 !== undefined) use24HourCheck.checked      = o.h24
+            pasteStatus.text = i18n("Applied!")
+        } catch(e) {
+            pasteStatus.text = i18n("Invalid config string")
+        }
+        pasteStatus.visible = true
+        statusTimer.restart()
+    }
+
+    Timer {
+        id: statusTimer
+        interval: 3000
+        onTriggered: pasteStatus.visible = false
+    }
+
+    Kirigami.FormLayout {
+        Layout.fillWidth: true
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Preset:")
+            spacing: Kirigami.Units.smallSpacing
+
+            Button {
+                icon.name: "edit-copy"
+                text: i18n("Copy style")
+                onClicked: {
+                    _hiddenField.text = root._serialize()
+                    _hiddenField.selectAll()
+                    _hiddenField.copy()
+                    pasteStatus.text = i18n("Copied!")
+                    pasteStatus.visible = true
+                    statusTimer.restart()
+                }
+            }
+
+            Button {
+                icon.name: "edit-paste"
+                text: i18n("Paste style")
+                onClicked: {
+                    _hiddenField.text = ""
+                    _hiddenField.paste()
+                    root._deserialize(_hiddenField.text)
+                }
+            }
+        }
+
+        TextField {
+            id: _hiddenField
+            visible: false
+        }
+
+        Label {
+            id: pasteStatus
+            visible: false
+            font.italic: true
+            opacity: 0.7
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+        }
+
+        ComboBox {
+            id: styleCombo
+            Kirigami.FormData.label: i18n("Style:")
+            model: [i18n("Glass"), i18n("Solid")]
+        }
+
+        ComboBox {
+            id: appearanceCombo
+            Kirigami.FormData.label: i18n("Appearance:")
+            model: [i18n("Dark"), i18n("Light"), i18n("Follow system")]
+        }
+
+        CheckBox {
+            id: use24HourCheck
+            Kirigami.FormData.label: i18n("Time format:")
+            text: i18n("Use 24-hour clock")
+        }
+
+        SpinBox {
+            id: radiusSpin
+            Kirigami.FormData.label: i18n("Corner radius (px):")
+            from: 0; to: 200; stepSize: 1
+        }
+
+        SpinBox {
+            id: roundnessSpin
+            Kirigami.FormData.label: i18n("Roundness (×10, 2.0..10.0):")
+            from: 20; to: 100; stepSize: 1
+        }
+    }
+
+    Kirigami.FormLayout {
+        id: glassSection
+        Layout.fillWidth: true
+        visible: styleCombo.currentIndex === 0
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Glass effect")
+        }
+
+        SpinBox {
+            id: thicknessSpin
+            Kirigami.FormData.label: i18n("Refraction thickness (px):")
+            from: 1; to: 80; stepSize: 1
+        }
+
+        SpinBox {
+            id: iorSpin
+            Kirigami.FormData.label: i18n("Index of refraction (×100):")
+            from: 100; to: 400; stepSize: 5
+        }
+
+        SpinBox {
+            id: scaleSpin
+            Kirigami.FormData.label: i18n("Refraction strength:")
+            from: 0; to: 300; stepSize: 5
+        }
+
+        SpinBox {
+            id: tintSpin
+            Kirigami.FormData.label: i18n("Tint alpha (%):")
+            from: 0; to: 100; stepSize: 1
+        }
+
+        SpinBox {
+            id: chromaSpin
+            Kirigami.FormData.label: i18n("Chromatic aberration (%):")
+            from: 0; to: 100; stepSize: 1
+        }
+
+        SpinBox {
+            id: specStrengthSpin
+            Kirigami.FormData.label: i18n("Specular strength (%):")
+            from: 0; to: 100; stepSize: 5
+        }
+
+        SpinBox {
+            id: blurRadiusSpin
+            Kirigami.FormData.label: i18n("Blur radius (px):")
+            from: 0; to: 100; stepSize: 1
+        }
+
+        CheckBox {
+            id: realtimeCheck
+            Kirigami.FormData.label: i18n("Realtime refraction:")
+            text: i18n("Recapture every frame (enable for video wallpapers)")
+        }
+    }
+}

--- a/packages/clock-digital/contents/ui/main.qml
+++ b/packages/clock-digital/contents/ui/main.qml
@@ -32,7 +32,10 @@ PlasmoidItem {
     // second-hand sweep does NOT read `now` — it reads Date.now()
     // directly every frame (avoids per-frame property churn).
     property date now: new Date()
-    readonly property int hour12: ((now.getHours() + 11) % 12) + 1
+    readonly property bool use24Hour: plasmoid.configuration.use24Hour
+    readonly property int hourDisplay: use24Hour
+        ? now.getHours()
+        : ((now.getHours() + 11) % 12) + 1
     readonly property int minute: now.getMinutes()
 
     Timer {
@@ -110,7 +113,8 @@ PlasmoidItem {
             // on both sides that the ticks leave to the edge (5% inset
             // + 5% tick length + 5% pad = 15% each side).
             availableWidth: Math.max(40, full.width - 2 * Math.min(full.width, full.height) * 0.15)
-            hour12: root.hour12
+            hour: root.hourDisplay
+            use24Hour: root.use24Hour
             minute: root.minute
             digitOpacity: colors.isGlass ? 0.55 : 1.0
             textColor: colors.foreground

--- a/packages/clock-digital/contents/ui/widget/DigitalTime.qml
+++ b/packages/clock-digital/contents/ui/widget/DigitalTime.qml
@@ -1,33 +1,29 @@
 import QtQuick
 
-// Condensed HH:MM readout. Layout: a centered Row with three items —
-// [hour] [colon-dots] [minute]. The dots live inside an Item whose
-// height matches the font's line height so they sit on the glyph
-// baseline-ish mid-x-height, vertically centered.
 Item {
     id: root
 
-    property int hour12: 12     // 1..12
-    property int minute: 0      // 0..59
-    // Desired font size. Actual rendered size is `_effectiveFontSize`,
-    // which scales down to fit `availableWidth` when the content (hour
-    // + colon + minute) would overflow (e.g. 12:45 vs 9:03).
+    property int hour: 12
+    property int minute: 0
+    property bool use24Hour: false
     property real fontPixelSize: 48
-    property real availableWidth: 0     // 0 disables auto-shrink
+    property real availableWidth: 0
     property real digitOpacity: 0.55
     property color textColor: "#ffffff"
     property string fontFamily: ""
 
-    // Measure the would-be content width at the requested fontPixelSize
-    // using a two-digit stand-in for each side (worst case), then scale
-    // down so the rendered layout fits `availableWidth` if given.
+    readonly property string hourText: use24Hour
+        ? (hour < 10 ? "0" + hour : String(hour))
+        : String(hour)
+    readonly property string minuteText: minute < 10 ? "0" + minute : String(minute)
+
     TextMetrics {
         id: hourMetrics
         font.family: root.fontFamily
         font.pixelSize: root.fontPixelSize
         font.weight: Font.Medium
         font.letterSpacing: -root.fontPixelSize * 0.03
-        text: String(root.hour12)
+        text: root.hourText
     }
     TextMetrics {
         id: minMetrics
@@ -35,27 +31,21 @@ Item {
         font.pixelSize: root.fontPixelSize
         font.weight: Font.Medium
         font.letterSpacing: -root.fontPixelSize * 0.03
-        text: root.minute < 10 ? "0" + root.minute : String(root.minute)
+        text: root.minuteText
     }
 
     readonly property real _naturalWidth:
         hourMetrics.width + minMetrics.width
-        + Math.max(3, Math.round(fontPixelSize * 0.10))  // dot column width
-        + 2 * (fontPixelSize * 0.10)                     // two gaps
+        + Math.max(3, Math.round(fontPixelSize * 0.10))
+        + 2 * (fontPixelSize * 0.10)
     readonly property real _scale:
         (availableWidth > 0 && _naturalWidth > availableWidth)
             ? availableWidth / _naturalWidth
             : 1
     readonly property real _effectiveFontSize: fontPixelSize * _scale
 
-    // Tight letter spacing for the "condensed" look.
     readonly property real _letterSpacing: -_effectiveFontSize * 0.03
-    // Gap between digits and colon on each side — small, for a
-    // compact cluster.
     readonly property real _gap: _effectiveFontSize * 0.10
-    // Dot diameter sized to match the font's stroke thickness so the
-    // colon reads as "part of the typeface" rather than a separate
-    // shape. Barlow Medium has a stroke ~10% of pixel size.
     readonly property real _dotDiameter: Math.max(3, Math.round(_effectiveFontSize * 0.10))
 
     implicitWidth: layout.implicitWidth
@@ -69,9 +59,9 @@ Item {
         spacing: root._gap
 
         Text {
-            id: hourText
+            id: hourLabel
             anchors.verticalCenter: parent.verticalCenter
-            text: root.hour12
+            text: root.hourText
             color: root.textColor
             opacity: root.digitOpacity
             font.family: root.fontFamily
@@ -81,13 +71,10 @@ Item {
             renderType: Text.NativeRendering
         }
 
-        // Colon dots. Parent Item's height equals the rendered text
-        // height; the two dots are then VERTICALLY CENTERED inside it
-        // as a single Column unit (no asymmetric placement).
         Item {
             id: dotHolder
             width: root._dotDiameter
-            height: hourText.height
+            height: hourLabel.height
             anchors.verticalCenter: parent.verticalCenter
 
             Column {
@@ -114,9 +101,8 @@ Item {
         }
 
         Text {
-            id: minText
             anchors.verticalCenter: parent.verticalCenter
-            text: root.minute < 10 ? "0" + root.minute : root.minute
+            text: root.minuteText
             color: root.textColor
             opacity: root.digitOpacity
             font.family: root.fontFamily


### PR DESCRIPTION
Allow toggling 12/24-hour display in Appearance settings while keeping the shared glass config layout for this widget only.