### PR TITLE
feat(music): add customizable no-lyrics message

### DIFF
--- a/packages/music/contents/config/main.xml
+++ b/packages/music/contents/config/main.xml
@@ -63,6 +63,9 @@
         <entry name="lyricsFontSizeTall" type="Int">
             <default>55</default>
         </entry>
+        <entry name="lyricsNotFoundMessage" type="String">
+            <default></default>
+        </entry>
         <entry name="artRefreshEnabled" type="Bool">
             <default>false</default>
         </entry>

--- a/packages/music/contents/ui/config/ConfigLyrics.qml
+++ b/packages/music/contents/ui/config/ConfigLyrics.qml
@@ -13,6 +13,7 @@ ColumnLayout {
     property alias cfg_lyricsFontSizeTall: tallFontSpin.value
     property alias cfg_lyricsBlur: lyricsBlurCheck.checked
     property alias cfg_artRefreshEnabled: artRefreshCheck.checked
+    property alias cfg_lyricsNotFoundMessage: notFoundField.text
 
     Kirigami.FormLayout {
         Layout.fillWidth: true
@@ -66,6 +67,25 @@ ColumnLayout {
             id: artRefreshCheck
             Kirigami.FormData.label: i18n("Pause on track change:")
             text: i18n("Briefly pause/resume to refresh album art (causes playback hiccups)")
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Not found message")
+        }
+
+        TextField {
+            id: notFoundField
+            Kirigami.FormData.label: i18n("No-lyrics message:")
+            placeholderText: i18n("Leave empty for default \u201cNo lyrics available\u201d")
+            Layout.fillWidth: true
+        }
+
+        Label {
+            Layout.fillWidth: true
+            text: i18n("Custom text shown when lyrics cannot be found for the current track.")
+            wrapMode: Text.WordWrap
+            opacity: 0.7
         }
 
     }

--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -585,6 +585,7 @@ PlasmoidItem {
             lyricsActiveOpacity: plasmoid.configuration.lyricsActiveOpacity / 100
             lyricsInactiveOpacity: plasmoid.configuration.lyricsInactiveOpacity / 100
             lyricsFontSizeFactor: plasmoid.configuration.lyricsFontSizeTall / 1000
+            lyricsNotFoundMessage: plasmoid.configuration.lyricsNotFoundMessage
             fontFamily: sfRegular.name
             fontFamilyThin: sfThin.name
             track: root.track
@@ -622,6 +623,7 @@ PlasmoidItem {
             lyricsActiveOpacity: plasmoid.configuration.lyricsActiveOpacity / 100
             lyricsInactiveOpacity: plasmoid.configuration.lyricsInactiveOpacity / 100
             lyricsFontSizeFactor: plasmoid.configuration.lyricsFontSizeWide / 1000
+            lyricsNotFoundMessage: plasmoid.configuration.lyricsNotFoundMessage
             fontFamily: sfRegular.name
             fontFamilyThin: sfThin.name
             track: root.track

--- a/packages/music/contents/ui/widget/SyncedLyricsView.qml
+++ b/packages/music/contents/ui/widget/SyncedLyricsView.qml
@@ -15,6 +15,7 @@ Item {
     property bool blurEnabled: true
     property real activeOpacity: 1.0
     property real inactiveOpacity: 0.40
+    property string notFoundMessage: ""
     readonly property real activeScale: 1.05
 
     signal seekTo(real positionUs)
@@ -231,14 +232,17 @@ Item {
 
     // ── Not found ─────────────────────────────────────────────────────────
     Text {
+        id: notFoundLabel
         anchors.centerIn: parent
         visible: lv.lyricsState === 4 || (lv.lyricsState === 2 && lv.syncedLyrics.length === 0 && lv.plainLyrics === "")
-        text: i18n("No lyrics available")
+        text: lv.notFoundMessage !== "" ? lv.notFoundMessage : i18n("No lyrics available")
         color: "#ffffff"
         opacity: 0.45
+        horizontalAlignment: Text.AlignHCenter
         font.pixelSize: Math.max(12, Math.round(lv.baseFontSize * 0.8))
         font.weight: Font.Medium
         font.family: lv.fontFamily
+        wrapMode: Text.WordWrap
     }
 
     // ── Error (tap to retry) ──────────────────────────────────────────────

--- a/packages/music/contents/ui/widget/TallWideLayout.qml
+++ b/packages/music/contents/ui/widget/TallWideLayout.qml
@@ -30,6 +30,7 @@ Item {
     property real lyricsActiveOpacity: 1.0
     property real lyricsInactiveOpacity: 0.40
     property real lyricsFontSizeFactor: 0.055
+    property string lyricsNotFoundMessage: ""
 
     signal togglePlaying()
     signal nextTrack()
@@ -161,6 +162,7 @@ Item {
                 blurEnabled: layout.lyricsBlur
                 activeOpacity: layout.lyricsActiveOpacity
                 inactiveOpacity: layout.lyricsInactiveOpacity
+                notFoundMessage: layout.lyricsNotFoundMessage
                 onSeekTo: function(posUs) { layout.seek(posUs) }
                 onRetryLyrics: layout.retryLyrics()
             }

--- a/packages/music/contents/ui/widget/WideLayout.qml
+++ b/packages/music/contents/ui/widget/WideLayout.qml
@@ -30,6 +30,7 @@ Item {
     property real lyricsActiveOpacity: 1.0
     property real lyricsInactiveOpacity: 0.40
     property real lyricsFontSizeFactor: 0.077
+    property string lyricsNotFoundMessage: ""
 
     signal togglePlaying()
     signal nextTrack()
@@ -206,6 +207,7 @@ Item {
             blurEnabled: layout.lyricsBlur
             activeOpacity: layout.lyricsActiveOpacity
             inactiveOpacity: layout.lyricsInactiveOpacity
+            notFoundMessage: layout.lyricsNotFoundMessage
             onSeekTo: function(posUs) { layout.seek(posUs) }
             onRetryLyrics: layout.retryLyrics()
         }


### PR DESCRIPTION
Add a configurable custom message shown when lyrics cannot be found for the current track.

**Changes:**
- New `lyricsNotFoundMessage` kcfg entry (`String`, default empty)
- New "Not found message" section in the Lyrics settings page (`ConfigLyrics.qml`) with a `TextField`
- Custom text is passed through `main.qml` \u2192 `TallWideLayout`/`WideLayout` \u2192 `SyncedLyricsView`
- `SyncedLyricsView` falls back to the default `i18n("No lyrics available")` when the field is empty
- Applies to both the 404 not-found state and the empty-lyrics state