### PR TITLE
feat: adds month navigation, user-defined custom events with color picking

### DIFF
--- a/1-common/components/MacOSColors.qml
+++ b/1-common/components/MacOSColors.qml
@@ -70,6 +70,10 @@ QtObject {
     readonly property real  cardHoverOpacity:      isLight ? 0.14 : 0.17
     readonly property real  cardPressOpacity:      isLight ? 0.20 : 0.22
 
+    // Hover tooltip — dark near-opaque surface in glass, theme surface in solid.
+    readonly property color tooltipBackground: isGlass ? "#2c2c2e" : surface
+    readonly property color tooltipForeground: isGlass ? "#ffffff" : solidForeground
+
     // Timer action colors — solid-filled in glass, tinted in solid.
     readonly property color countdownText:  isGlass ? "#ffffff" : "#FF8B00"
     readonly property color actionGreen:    "#00A832"

--- a/packages/calendar/contents/config/main.xml
+++ b/packages/calendar/contents/config/main.xml
@@ -51,5 +51,8 @@
         <entry name="enabledCalendarPlugins" type="StringList">
             <default>pimevents,holidaysevents</default>
         </entry>
+        <entry name="customEvents" type="String">
+            <default>[]</default>
+        </entry>
     </group>
 </kcfg>

--- a/packages/calendar/contents/ui/main.qml
+++ b/packages/calendar/contents/ui/main.qml
@@ -271,10 +271,32 @@ PlasmoidItem {
     }
 
     function _syncCalendarBackends() {
+        calendarBackend.goToYearAndMonth(viewYear, viewMonth + 1);
         var d1 = new Date(viewYear, viewMonth + 1, 1);
         nextMonthBackend.goToYearAndMonth(d1.getFullYear(), d1.getMonth() + 1);
         var d2 = new Date(viewYear, viewMonth + 2, 1);
         thirdMonthBackend.goToYearAndMonth(d2.getFullYear(), d2.getMonth() + 1);
+    }
+
+    function goPrevMonth() {
+        if (viewMonth === 0) {
+            viewMonth = 11;
+            viewYear -= 1;
+        } else {
+            viewMonth -= 1;
+        }
+    }
+    function goNextMonth() {
+        if (viewMonth === 11) {
+            viewMonth = 0;
+            viewYear += 1;
+        } else {
+            viewMonth += 1;
+        }
+    }
+    function goToToday() {
+        viewYear = today.getFullYear();
+        viewMonth = today.getMonth();
     }
 
     // Pick the right DaysModel for a given date
@@ -350,6 +372,85 @@ PlasmoidItem {
 
         var now = root.today;
         var todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+        // When viewing a month other than the current one, list events across
+        // the displayed month plus the configured lookahead window (the same
+        // "show events for" value used by the current-month view), grouped by
+        // month in chronological order.
+        if (viewYear !== now.getFullYear() || viewMonth !== now.getMonth()) {
+            const customsAll = _parseCustomEvents();
+            const seenKeys = {};
+            const anchor = new Date(viewYear, viewMonth, 1);
+            const end = new Date(anchor.getTime() + effectiveLookahead * 86400000);
+            const buckets = [];  // { year, month, entries: [] } in chronological order
+
+            for (let d = new Date(anchor); d < end; d = new Date(d.getTime() + 86400000)) {
+                let b = buckets.length > 0 ? buckets[buckets.length - 1] : null;
+                if (!b || b.year !== d.getFullYear() || b.month !== d.getMonth()) {
+                    b = { year: d.getFullYear(), month: d.getMonth(), entries: [] };
+                    buckets.push(b);
+                }
+
+                const dm = _daysModelForDate(d);
+                const raw = dm.eventsForDate(d);
+                if (raw && raw.length > 0) {
+                    const evs = [];
+                    for (let ei = 0; ei < raw.length; ei++) evs.push(raw[ei]);
+                    evs.sort(function(a, b2) {
+                        if (a.isAllDay && !b2.isAllDay) return -1;
+                        if (!a.isAllDay && b2.isAllDay) return 1;
+                        return a.startDateTime.getTime() - b2.startDateTime.getTime();
+                    });
+                    for (let e = 0; e < evs.length; e++) {
+                        const ev = evs[e];
+                        const key = ev.title + "|" + ev.startDateTime.getTime();
+                        if (seenKeys[key]) continue;
+                        seenKeys[key] = true;
+                        b.entries.push({
+                            isHeader: false,
+                            title: ev.title,
+                            pillColor: _pillColorFor(ev),
+                            isAllDay: ev.isAllDay,
+                            timeLabel: _formatWeekDate(d),
+                            isCustom: false,
+                            eventId: "",
+                            sortTime: ev.startDateTime.getTime()
+                        });
+                    }
+                }
+
+                const key2 = _dateKey(d);
+                for (let c = 0; c < customsAll.length; c++) {
+                    if (customsAll[c].date === key2) {
+                        b.entries.push({
+                            isHeader: false,
+                            title: customsAll[c].title,
+                            pillColor: customsAll[c].color || customEventColor,
+                            isAllDay: true,
+                            timeLabel: _formatWeekDate(d),
+                            isCustom: true,
+                            eventId: String(customsAll[c].id),
+                            sortTime: d.getTime()
+                        });
+                    }
+                }
+            }
+
+            const cmp = function(a, b2) {
+                if (a.isAllDay && !b2.isAllDay) return -1;
+                if (!a.isAllDay && b2.isAllDay) return 1;
+                return a.sortTime - b2.sortTime;
+            };
+            for (let bi = 0; bi < buckets.length; bi++) {
+                const b = buckets[bi];
+                if (b.entries.length === 0) continue;
+                b.entries.sort(cmp);
+                eventsModel.append({ isHeader: true, title: monthNames[b.month] + " " + b.year, pillColor: "", timeLabel: "", isAllDay: false });
+                for (let e = 0; e < b.entries.length; e++) eventsModel.append(b.entries[e]);
+            }
+            rebuildDayDots();
+            return;
+        }
 
         // End of current week (exclusive): the first day of next week
         // Sun-first: week ends Saturday (day 6), so next week starts Sunday
@@ -665,22 +766,63 @@ PlasmoidItem {
                 Layout.fillWidth: true
                 Layout.preferredHeight: full.labelSize * 1.4
 
-                TextMetrics {
-                    id: sMetrics
-                    font.family: sfRegular.name
-                    font.pixelSize: full.labelSize
-                    text: root.weekdayShort[0]
+                Item {
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Math.round(full.labelSize * 1.4)
+                    height: Math.round(full.labelSize * 1.4)
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "\u2039"
+                        color: colors.foreground
+                        opacity: prevMouse.containsMouse ? 1.0 : 0.6
+                        font.family: sfRegular.name
+                        font.pixelSize: Math.round(full.labelSize * 1.3)
+                    }
+                    MouseArea {
+                        id: prevMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: root.goPrevMonth()
+                    }
+                }
+
+                Item {
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Math.round(full.labelSize * 1.4)
+                    height: Math.round(full.labelSize * 1.4)
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "\u203A"
+                        color: colors.foreground
+                        opacity: nextMouse.containsMouse ? 1.0 : 0.6
+                        font.family: sfRegular.name
+                        font.pixelSize: Math.round(full.labelSize * 1.3)
+                    }
+                    MouseArea {
+                        id: nextMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: root.goNextMonth()
+                    }
                 }
 
                 Text {
-                    x: parent.width / 7 / 2 - sMetrics.width / 2
+                    anchors.horizontalCenter: parent.horizontalCenter
                     anchors.verticalCenter: parent.verticalCenter
-                    text: root.monthNames[root.viewMonth].toUpperCase()
+                    text: root.monthNames[root.viewMonth].toUpperCase() + " " + root.viewYear
                     color: colors.todayAccent
                     font.family: sfRegular.name
                     font.pixelSize: full.labelSize
                     font.weight: Font.Regular
                     font.letterSpacing: 1
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: root.goToToday()
+                    }
                 }
             }
 

--- a/packages/calendar/contents/ui/main.qml
+++ b/packages/calendar/contents/ui/main.qml
@@ -44,6 +44,10 @@ PlasmoidItem {
 
     // Precomputed day-of-month per grid slot [0..41]; 0 means empty.
     property var monthDays: []
+    // Per-slot indicator dot color [0..41]; "" means no event/holiday on that day.
+    property var dayDots: []
+    // Per-slot tooltip text [0..41]; "" means no events/holidays on that day.
+    property var dayTitles: []
     function rebuildMonthDays() {
         const firstOfMonth = new Date(viewYear, viewMonth, 1);
         let offset = firstOfMonth.getDay() - firstDow;
@@ -56,6 +60,42 @@ PlasmoidItem {
             out[i] = (day < 1 || day > lastDay) ? 0 : day;
         }
         monthDays = out;
+        rebuildDayDots();
+    }
+
+    // Event summaries for a grid slot, used for dots and hover tooltips.
+    function _eventsForSlot(i) {
+        if (!monthDays[i]) return [];
+        const d = new Date(viewYear, viewMonth, monthDays[i]);
+        const dm = _daysModelForDate(d);
+        const raw = dm.eventsForDate(d);
+        if (!raw || raw.length === 0) return [];
+        const out = [];
+        for (let e = 0; e < raw.length; e++) {
+            const ev = raw[e];
+            out.push({
+                title: ev.title,
+                color: _pillColorFor(ev),
+                isHoliday: ev.eventType === "Holiday"
+            });
+        }
+        return out;
+    }
+    function rebuildDayDots() {
+        const dots = new Array(42);
+        const titles = new Array(42);
+        for (let i = 0; i < 42; i++) {
+            const evs = _eventsForSlot(i);
+            let color = "";
+            for (let e = 0; e < evs.length; e++) {
+                if (evs[e].isHoliday) { color = evs[e].color; break; }
+            }
+            if (!color && evs.length > 0) color = evs[0].color;
+            dots[i] = color;
+            titles[i] = evs.map(function (ev) { return ev.title; }).join("\n");
+        }
+        dayDots = dots;
+        dayTitles = titles;
     }
     onViewYearChanged: {
         rebuildMonthDays();
@@ -325,6 +365,7 @@ PlasmoidItem {
             for (var ui = 0; ui < upcomingEvents.length; ui++) eventsModel.append(upcomingEvents[ui]);
         }
 
+        rebuildDayDots();
     }
 
     fullRepresentation: Item {
@@ -338,6 +379,11 @@ PlasmoidItem {
         readonly property real wideGap: Math.round(full.height * 0.04)
         // Single unified type scale — everything uses this size.
         readonly property real labelSize: Math.max(10, Math.round(full.height * 0.058))
+
+        // Hover state for the day-grid tooltip (coordinates in full's space).
+        property string dayHoverText: ""
+        property real dayHoverCenterX: 0
+        property real dayHoverTop: 0
 
         LiquidGlass {
             id: glass
@@ -560,6 +606,7 @@ PlasmoidItem {
                             readonly property bool empty: day === 0
                             readonly property bool isCurrent: !empty && day === root.today.getDate() && root.viewMonth === root.today.getMonth() && root.viewYear === root.today.getFullYear()
                             readonly property bool isWeekend: root.isWeekendCol(index % 7)
+                            readonly property real dotDiameter: Math.max(3, Math.round(full.labelSize * 0.3))
 
                             Text {
                                 anchors.centerIn: parent
@@ -588,9 +635,75 @@ PlasmoidItem {
                                 textColor: "#ffffff"
                                 punchOutText: colors.punchOutText
                             }
+
+                            Rectangle {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                y: parent.height / 2 + full.labelSize * 0.55
+                                width: dotDiameter
+                                height: dotDiameter
+                                radius: dotDiameter / 2
+                                visible: !empty && !isCurrent && root.dayDots[index] !== ""
+                                color: root.dayDots[index] !== "" ? root.dayDots[index] : "transparent"
+                            }
                         }
                     }
                 }
+
+                MouseArea {
+                    id: gridHover
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    onEntered: gridHover._update(gridHover.mouseX, gridHover.mouseY)
+                    onPositionChanged: (mouse) => gridHover._update(mouse.x, mouse.y)
+                    onExited: full.dayHoverText = ""
+
+                    function _update(mx, my) {
+                        const col = Math.floor(mx / gridWrap.cellW);
+                        const row = Math.floor(my / gridWrap.cellH);
+                        const idx = row * 7 + col;
+                        if (idx >= 0 && idx < 42 && root.dayTitles[idx] !== "") {
+                            const p = mapToItem(full, col * gridWrap.cellW, row * gridWrap.cellH);
+                            full.dayHoverText = root.dayTitles[idx];
+                            full.dayHoverCenterX = p.x + gridWrap.cellW / 2;
+                            full.dayHoverTop = p.y;
+                        } else {
+                            full.dayHoverText = "";
+                        }
+                    }
+                }
+            }
+        }
+
+        // Hover tooltip for day dots (positioned in full's coordinate space).
+        Item {
+            id: dayTooltip
+            visible: full.dayHoverText !== ""
+            z: 10
+
+            readonly property real tipPad: Math.round(full.labelSize * 0.55)
+            readonly property real maxW: full.width * 0.8
+            width: Math.min(tooltipLabel.implicitWidth + 2 * tipPad, maxW)
+            height: tooltipLabel.implicitHeight + 2 * tipPad
+            x: Math.max(2, Math.min(full.dayHoverCenterX - width / 2, full.width - width - 2))
+            y: Math.max(2, full.dayHoverTop - height - Math.round(full.labelSize * 0.35))
+
+            Rectangle {
+                anchors.fill: parent
+                radius: Math.round(full.labelSize * 0.45)
+                color: colors.tooltipBackground
+            }
+
+            Text {
+                id: tooltipLabel
+                anchors.centerIn: parent
+                width: dayTooltip.width - 2 * dayTooltip.tipPad
+                text: full.dayHoverText
+                color: colors.tooltipForeground
+                font.family: sfRegular.name
+                font.pixelSize: Math.round(full.labelSize * 0.85)
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             }
         }
     }

--- a/packages/calendar/contents/ui/main.qml
+++ b/packages/calendar/contents/ui/main.qml
@@ -67,17 +67,29 @@ PlasmoidItem {
     function _eventsForSlot(i) {
         if (!monthDays[i]) return [];
         const d = new Date(viewYear, viewMonth, monthDays[i]);
+        const out = [];
         const dm = _daysModelForDate(d);
         const raw = dm.eventsForDate(d);
-        if (!raw || raw.length === 0) return [];
-        const out = [];
-        for (let e = 0; e < raw.length; e++) {
-            const ev = raw[e];
-            out.push({
-                title: ev.title,
-                color: _pillColorFor(ev),
-                isHoliday: ev.eventType === "Holiday"
-            });
+        if (raw && raw.length > 0) {
+            for (let e = 0; e < raw.length; e++) {
+                const ev = raw[e];
+                out.push({
+                    title: ev.title,
+                    color: _pillColorFor(ev),
+                    isHoliday: ev.eventType === "Holiday"
+                });
+            }
+        }
+        const key = _dateKey(d);
+        const customs = _parseCustomEvents();
+        for (let c = 0; c < customs.length; c++) {
+            if (customs[c].date === key) {
+                out.push({
+                    title: customs[c].title,
+                    color: customs[c].color || customEventColor,
+                    isHoliday: false
+                });
+            }
         }
         return out;
     }
@@ -97,6 +109,60 @@ PlasmoidItem {
         dayDots = dots;
         dayTitles = titles;
     }
+
+    // --- Custom (user-added) events --------------------------------------
+    // Stored in plasmoid config as a JSON array of { id, title, date, color },
+    // where date is a "yyyy-mm-dd" string (local) and color is a hex string.
+    // Always all-day.
+    readonly property color customEventColor: "#BF5AF2"
+
+    // Preset event colors (macOS-style), shown as swatches in the add dialog.
+    readonly property var customEventPalette: [
+        "#FF3B30",   // red
+        "#FF9500",   // orange
+        "#FFD60A",   // yellow
+        "#34C759",   // green
+        "#00C7BE",   // teal
+        "#0A84FF",   // blue
+        "#BF5AF2",   // purple
+        "#FF2D55"    // pink
+    ]
+
+    property var addEventDate: new Date()
+    property string addEventColor: "#BF5AF2"
+    property bool addDialogOpen: false
+
+    function _dateKey(d) {
+        const m = ("0" + (d.getMonth() + 1)).slice(-2);
+        const day = ("0" + d.getDate()).slice(-2);
+        return d.getFullYear() + "-" + m + "-" + day;
+    }
+    function _parseDateKey(key) {
+        const p = key.split("-");
+        return new Date(parseInt(p[0], 10), parseInt(p[1], 10) - 1, parseInt(p[2], 10));
+    }
+    function _parseCustomEvents() {
+        try {
+            const arr = JSON.parse(plasmoid.configuration.customEvents);
+            return Array.isArray(arr) ? arr : [];
+        } catch (e) {
+            return [];
+        }
+    }
+    function _saveCustomEvents(arr) {
+        plasmoid.configuration.customEvents = JSON.stringify(arr);
+        _scheduleRebuildEvents();
+    }
+    function _addCustomEvent(title, dateKey, color) {
+        const arr = _parseCustomEvents();
+        arr.push({ id: Date.now(), title: title, date: dateKey, color: color });
+        _saveCustomEvents(arr);
+    }
+    function _removeCustomEvent(id) {
+        const arr = _parseCustomEvents();
+        _saveCustomEvents(arr.filter(function (e) { return String(e.id) !== String(id); }));
+    }
+
     onViewYearChanged: {
         rebuildMonthDays();
         _syncCalendarBackends();
@@ -333,7 +399,10 @@ PlasmoidItem {
                     title: ev.title,
                     pillColor: _pillColorFor(ev),
                     isAllDay: ev.isAllDay,
-                    timeLabel: ""
+                    timeLabel: "",
+                    isCustom: false,
+                    eventId: "",
+                    sortTime: ev.startDateTime.getTime()
                 };
 
                 var dTime = d.getTime();
@@ -351,6 +420,47 @@ PlasmoidItem {
                 }
             }
         }
+
+        // Merge custom (user-added) events into the same buckets.
+        var customs = _parseCustomEvents();
+        for (var ci = 0; ci < customs.length; ci++) {
+            var ce = customs[ci];
+            if (!ce.date || !ce.title) continue;
+            var cd = _parseDateKey(ce.date);
+            if (cd.getTime() < todayStart.getTime() || cd.getTime() >= lookaheadEnd.getTime()) continue;
+
+            var centry = {
+                isHeader: false,
+                title: ce.title,
+                pillColor: ce.color || customEventColor,
+                isAllDay: true,
+                timeLabel: "",
+                isCustom: true,
+                eventId: String(ce.id),
+                sortTime: cd.getTime()
+            };
+
+            if (cd.getTime() === todayStart.getTime()) {
+                centry.timeLabel = i18n("All day");
+                todayEvents.push(centry);
+            } else if (cd < weekEnd) {
+                centry.timeLabel = _formatWeekDate(cd);
+                weekEvents.push(centry);
+            } else {
+                centry.timeLabel = _formatUpcomingDate(cd);
+                upcomingEvents.push(centry);
+            }
+        }
+
+        // Re-sort each bucket so custom events land in date order (all-day first).
+        var bucketCompare = function(a, b) {
+            if (a.isAllDay && !b.isAllDay) return -1;
+            if (!a.isAllDay && b.isAllDay) return 1;
+            return a.sortTime - b.sortTime;
+        };
+        todayEvents.sort(bucketCompare);
+        weekEvents.sort(bucketCompare);
+        upcomingEvents.sort(bucketCompare);
 
         if (todayEvents.length > 0) {
             eventsModel.append({ isHeader: true, title: i18n("Events today"), pillColor: "", timeLabel: "", isAllDay: false });
@@ -384,6 +494,19 @@ PlasmoidItem {
         property string dayHoverText: ""
         property real dayHoverCenterX: 0
         property real dayHoverTop: 0
+
+        function confirmAddEvent() {
+            const title = addTitleInput.text.trim();
+            if (title.length === 0) {
+                addTitleInput.forceActiveFocus();
+                return;
+            }
+            root._addCustomEvent(title, root._dateKey(root.addEventDate), root.addEventColor);
+            root.addDialogOpen = false;
+        }
+        function closeAddDialog() {
+            root.addDialogOpen = false;
+        }
 
         LiquidGlass {
             id: glass
@@ -465,9 +588,14 @@ PlasmoidItem {
                                 item.headerTitle = model.title;
                                 item.isFirstHeader = (index === 0);
                             } else {
+                                const evId = model.eventId;
                                 item.cardTitle = model.title;
                                 item.cardTime = model.timeLabel;
                                 item.cardPill = model.pillColor;
+                                item.cardCustom = model.isCustom === true;
+                                item.deleteRequested.connect(function() {
+                                    root._removeCustomEvent(evId);
+                                });
                             }
                         }
                     }
@@ -498,11 +626,13 @@ PlasmoidItem {
                     property string cardTitle: ""
                     property string cardTime: ""
                     property string cardPill: ""
+                    property bool cardCustom: false
 
                     width: parent ? parent.width : 0
                     title: cardTitle
                     timeLabel: cardTime
                     pillColor: cardPill
+                    isCustom: cardCustom
                     textColor: colors.foreground
                     fontFamily: sfRegular.name
                     fontSize: leftPanel._cardSize
@@ -653,10 +783,11 @@ PlasmoidItem {
                     id: gridHover
                     anchors.fill: parent
                     hoverEnabled: true
-                    acceptedButtons: Qt.NoButton
+                    acceptedButtons: Qt.LeftButton
                     onEntered: gridHover._update(gridHover.mouseX, gridHover.mouseY)
                     onPositionChanged: (mouse) => gridHover._update(mouse.x, mouse.y)
                     onExited: full.dayHoverText = ""
+                    onClicked: (mouse) => gridHover._openAdd(mouse.x, mouse.y)
 
                     function _update(mx, my) {
                         const col = Math.floor(mx / gridWrap.cellW);
@@ -670,6 +801,17 @@ PlasmoidItem {
                         } else {
                             full.dayHoverText = "";
                         }
+                    }
+
+                    function _openAdd(mx, my) {
+                        const col = Math.floor(mx / gridWrap.cellW);
+                        const row = Math.floor(my / gridWrap.cellH);
+                        const idx = row * 7 + col;
+                        if (idx < 0 || idx >= 42 || !root.monthDays[idx]) return;
+                        full.dayHoverText = "";
+                        root.addEventDate = new Date(root.viewYear, root.viewMonth, root.monthDays[idx]);
+                        addTitleInput.text = "";
+                        root.addDialogOpen = true;
                     }
                 }
             }
@@ -704,6 +846,201 @@ PlasmoidItem {
                 font.pixelSize: Math.round(full.labelSize * 0.85)
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+            }
+        }
+
+        // Add-event dialog (opened by clicking a day cell).
+        Item {
+            id: addDialog
+            anchors.fill: parent
+            visible: root.addDialogOpen
+            z: 20
+
+            onVisibleChanged: {
+                if (visible)
+                    addFocusTimer.start();
+            }
+
+            Timer {
+                id: addFocusTimer
+                interval: 0
+                repeat: false
+                onTriggered: addTitleInput.forceActiveFocus()
+            }
+
+            Rectangle {
+                anchors.fill: parent
+                color: "#000000"
+                // Glass mode: no dim backdrop (it fights the liquid-glass look).
+                // Solid mode: dim, with corners matching the widget's radius.
+                opacity: colors.isGlass ? 0.0 : 0.35
+                radius: colors.isGlass ? 0 : plasmoid.configuration.cornerRadius
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: full.closeAddDialog()
+                }
+            }
+
+            Item {
+                id: dialogCard
+                anchors.centerIn: parent
+                width: Math.min(full.width * 0.8, 340)
+                height: dialogColumn.height + 2 * dialogCard.cardPad
+
+                readonly property real cardPad: Math.round(full.labelSize * 0.9)
+
+                LiquidGlass {
+                    anchors.fill: parent
+                    radius: Math.min(plasmoid.configuration.cornerRadius, 26)
+                    roundness: plasmoid.configuration.roundnessX10 / 10
+                    refractThickness: plasmoid.configuration.refractThickness
+                    refractIOR: plasmoid.configuration.refractIORx100 / 100
+                    refractScale: plasmoid.configuration.refractScale
+                    tint: colors.glassTint
+                    tintAlpha: plasmoid.configuration.tintAlphaPct / 100
+                    chromaStrength: plasmoid.configuration.chromaStrengthPct / 100
+                    specStrength: plasmoid.configuration.specStrengthPct / 100
+                    blurRadius: plasmoid.configuration.blurRadiusPx
+                    realtimeRefraction: plasmoid.configuration.realtimeRefraction
+                    fallbackOpacity: colors.glassFallbackOpacity
+                    solidMode: colors.isSolid
+                    solidColor: colors.solidBackground
+                }
+
+                Column {
+                    id: dialogColumn
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    y: dialogCard.cardPad
+                    width: dialogCard.width - 2 * dialogCard.cardPad
+                    spacing: Math.round(full.labelSize * 0.45)
+
+                    Text {
+                        text: i18n("New Event")
+                        color: colors.foreground
+                        font.family: sfRegular.name
+                        font.pixelSize: full.labelSize
+                    }
+
+                    Text {
+                        text: Qt.formatDateTime(root.addEventDate, "dddd, MMMM d")
+                        color: colors.foreground
+                        opacity: 0.6
+                        font.family: sfRegular.name
+                        font.pixelSize: Math.round(full.labelSize * 0.78)
+                    }
+
+                    Item {
+                        width: parent.width
+                        height: Math.round(full.labelSize * 1.9)
+
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: Math.round(full.labelSize * 0.4)
+                            color: colors.cardBackground
+                            opacity: colors.cardBackgroundOpacity
+                        }
+
+                        TextInput {
+                            id: addTitleInput
+                            anchors.fill: parent
+                            anchors.leftMargin: Math.round(full.labelSize * 0.5)
+                            anchors.rightMargin: Math.round(full.labelSize * 0.5)
+                            verticalAlignment: TextInput.AlignVCenter
+                            color: colors.foreground
+                            font.family: sfRegular.name
+                            font.pixelSize: full.labelSize
+                            activeFocusOnTab: true
+                            selectByMouse: true
+                            onAccepted: full.confirmAddEvent()
+                            Keys.onEscapePressed: full.closeAddDialog()
+                        }
+
+                        Text {
+                            anchors.left: parent.left
+                            anchors.leftMargin: Math.round(full.labelSize * 0.5)
+                            anchors.verticalCenter: parent.verticalCenter
+                            visible: addTitleInput.text === ""
+                            text: i18n("Event title")
+                            color: colors.foreground
+                            opacity: 0.4
+                            font.family: sfRegular.name
+                            font.pixelSize: full.labelSize
+                        }
+                    }
+
+                    Flow {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: parent.width
+                        spacing: Math.round(full.labelSize * 0.35)
+
+                        Repeater {
+                            model: root.customEventPalette
+                            delegate: Rectangle {
+                                readonly property real swatchSize: Math.round(full.labelSize * 1.3)
+                                width: swatchSize
+                                height: swatchSize
+                                radius: swatchSize / 2
+                                color: modelData
+                                border.width: root.addEventColor === modelData ? 2 : 0
+                                border.color: colors.foreground
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    onClicked: root.addEventColor = modelData
+                                }
+                            }
+                        }
+                    }
+
+                    Row {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        spacing: Math.round(full.labelSize * 0.5)
+
+                        Item {
+                            width: Math.round(full.labelSize * 4.2)
+                            height: Math.round(full.labelSize * 1.7)
+
+                            Rectangle {
+                                anchors.fill: parent
+                                radius: Math.round(full.labelSize * 0.5)
+                                color: colors.cardBackground
+                                opacity: colors.cardBackgroundOpacity
+                            }
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: i18n("Cancel")
+                                color: colors.foreground
+                                font.family: sfRegular.name
+                                font.pixelSize: Math.round(full.labelSize * 0.85)
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: full.closeAddDialog()
+                            }
+                        }
+
+                        Rectangle {
+                            width: Math.round(full.labelSize * 4.2)
+                            height: Math.round(full.labelSize * 1.7)
+                            radius: Math.round(full.labelSize * 0.5)
+                            color: colors.accent
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: i18n("Add")
+                                color: "#ffffff"
+                                font.family: sfRegular.name
+                                font.pixelSize: Math.round(full.labelSize * 0.85)
+                            }
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: full.confirmAddEvent()
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/packages/calendar/contents/ui/main.qml
+++ b/packages/calendar/contents/ui/main.qml
@@ -591,6 +591,16 @@ PlasmoidItem {
         // Single unified type scale — everything uses this size.
         readonly property real labelSize: Math.max(10, Math.round(full.height * 0.058))
 
+        // The glass squircle's corner is sharper than a plain rounded rect
+        // with the same "radius". Convert the config cornerRadius into the
+        // equivalent circle radius (matching the superellipse at the 45°
+        // apex) so the solid-mode backdrop hugs the widget's corners.
+        readonly property real modalBackdropRadius: {
+            const n = Math.max(2, plasmoid.configuration.roundnessX10 / 10);
+            const factor = (1 - Math.pow(2, -1 / n)) / (1 - Math.pow(2, -0.5));
+            return Math.round(plasmoid.configuration.cornerRadius * factor);
+        }
+
         // Hover state for the day-grid tooltip (coordinates in full's space).
         property string dayHoverText: ""
         property real dayHoverCenterX: 0
@@ -1014,9 +1024,9 @@ PlasmoidItem {
                 anchors.fill: parent
                 color: "#000000"
                 // Glass mode: no dim backdrop (it fights the liquid-glass look).
-                // Solid mode: dim, with corners matching the widget's radius.
+                // Solid mode: dim, with corners matched to the widget's squircle.
                 opacity: colors.isGlass ? 0.0 : 0.35
-                radius: colors.isGlass ? 0 : plasmoid.configuration.cornerRadius
+                radius: colors.isGlass ? 0 : full.modalBackdropRadius
                 MouseArea {
                     anchors.fill: parent
                     onClicked: full.closeAddDialog()

--- a/packages/calendar/contents/ui/widget/EventCard.qml
+++ b/packages/calendar/contents/ui/widget/EventCard.qml
@@ -11,6 +11,9 @@ Item {
     property real fontSize: 11
     property color cardBg: "#ffffff"
     property real cardBgOpacity: 0.10
+    property bool isCustom: false
+
+    signal deleteRequested()
 
     readonly property real _pad: Math.round(height * 0.22)
 
@@ -51,10 +54,44 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: card._pad
         anchors.verticalCenter: parent.verticalCenter
+        visible: !deleteBtn.visible
         text: card.timeLabel
         color: card.textColor
         opacity: 0.6
         font.family: card.fontFamily
         font.pixelSize: Math.round(card.fontSize * 0.85)
+    }
+
+    MouseArea {
+        id: cardHover
+        anchors.fill: parent
+        hoverEnabled: card.isCustom
+        onClicked: (mouse) => {
+            if (card.isCustom && deleteBtn.visible) {
+                const p = mapToItem(deleteBtn, mouse.x, mouse.y);
+                if (p.x >= 0 && p.y >= 0 && p.x <= deleteBtn.width && p.y <= deleteBtn.height)
+                    card.deleteRequested();
+            }
+        }
+    }
+
+    Rectangle {
+        id: deleteBtn
+        anchors.right: parent.right
+        anchors.rightMargin: card._pad
+        anchors.verticalCenter: parent.verticalCenter
+        visible: card.isCustom && cardHover.containsMouse
+        width: Math.round(card.height * 0.42)
+        height: width
+        radius: width / 2
+        color: Qt.rgba(1, 1, 1, 0.15)
+
+        Text {
+            anchors.centerIn: parent
+            text: "\u00D7"
+            color: card.textColor
+            font.family: card.fontFamily
+            font.pixelSize: Math.round(card.fontSize * 0.9)
+        }
     }
 }


### PR DESCRIPTION
Hi, thank you for this project with gorgeous widgets!

I have added these to make the calendar more feature rich, please consider a merge if you find these useful:

- Highlight event/holiday dates on grid — Adds colored dots under dates with events/holidays and a hover tooltip showing the event name.
- Custom events with color picking — Users can add their own events (title + date + color) via a liquid-glass dialog. Events persist in widget config and appear in both the grid dots and the events list.
- Month navigation — ‹ / › chevrons at header ends, centered month/year label, click title → jump to today, backend sync so the displayed month's events load correctly.

## Testing notes
- Verified on Plasma 6 + Qt 6 (Wayland + X11).
- ./install.sh calendar to install; ./test.reload.sh calendar for rapid iteration.
- Grid dots + list now correctly reflect the displayed month; show events for lookahead (config) honored when navigating.

<img width="602" height="300" alt="image" src="https://github.com/user-attachments/assets/8939906d-04e2-47c3-bb10-28c15374b69e" />
<img width="604" height="302" alt="image" src="https://github.com/user-attachments/assets/78a11a3b-da35-4ade-9cc0-69a8a5ae9024" />
<img width="596" height="292" alt="image" src="https://github.com/user-attachments/assets/6dbb6856-f6fc-460c-ba4d-b76948453326" />
<img width="599" height="299" alt="image" src="https://github.com/user-attachments/assets/47753f88-c86b-4f0a-9fd0-b7f68d6fdd83" />

