### PR TITLE
Fix music player filter fallback

### DIFF
--- a/packages/music/contents/ui/main.qml
+++ b/packages/music/contents/ui/main.qml
@@ -68,7 +68,7 @@ PlasmoidItem {
             if (p && _isPlayerAllowed(p.identity) && (p.track || p.artist))
                 return p
         }
-        return cp
+        return null
     }
     readonly property bool _playerAllowed: {
         var cp = mpris2Model.currentPlayer


### PR DESCRIPTION
Hey, so when Deny music players was selected, the widget still displayed the denied player if it was the current MPRIS player.

The ( _activePlayer )logic falls back to return cp when no allowed player is found, which causes the denied current player to be returned anyway.

So what i did is i changed the fallback to return null so that the denied players are actually excluded from showing up in the widget. 

I tested this with youtube playing in my browser.