### PR TITLE
fix(liquidglass): stop the blur chain redrawing at full framerate

### DIFF
--- a/1-common/components/LiquidGlass.qml
+++ b/1-common/components/LiquidGlass.qml
@@ -107,7 +107,46 @@ Item {
         // If realtime is off, force a one-shot backdrop recapture so the
         // sampled wallpaper stays aligned after the widget moves.
         if (moved && !realtimeRefraction) wallpaperTex.scheduleUpdate()
+        if (moved) markDirty()
     }
+
+    // --- Redraw gating -------------------------------------------------
+    //
+    // The blur pyramid below is a chain of ShaderEffectSources feeding one
+    // another. Leaving every link `live` means the scene graph never reaches
+    // a resting state: each link dirties the next, so plasmashell re-blurs
+    // the wallpaper at full framerate for as long as the widget exists, even
+    // though a static wallpaper produces byte-identical output every frame.
+    //
+    // So the chain only runs in bursts. Anything that can change a pixel
+    // calls markDirty(), which lets the chain render freely for a short
+    // while and then parks it. The burst is deliberately several frames
+    // long rather than a single scheduleUpdate() per link: the links settle
+    // one stage per frame, and a burst lets the whole pyramid flush through
+    // without having to hand-order the updates.
+    property bool _dirtyBurst: false
+    function markDirty() {
+        _dirtyBurst = true
+        settleTimer.restart()
+    }
+    Timer {
+        id: settleTimer
+        interval: 250
+        onTriggered: glass._dirtyBurst = false
+    }
+    readonly property bool _chainLive: glass._blurActive
+                                       && (glass.realtimeRefraction || glass._dirtyBurst)
+
+    // Re-blur whenever the inputs to the blur actually change.
+    onWidthChanged: markDirty()
+    onHeightChanged: markDirty()
+    onBlurRadiusChanged: markDirty()
+    onSolidModeChanged: markDirty()
+    onWallpaperItemChanged: markDirty()
+    onRealtimeRefractionChanged: markDirty()
+    // _blurActive has no bindable handler name (the leading underscore makes
+    // one ambiguous), so burst on its three inputs instead.
+    onActiveChanged: markDirty()
 
     // --- Mouse tracking for specular highlight ---
     // _mouseU/_mouseV are in widget-local UV (0..1). (-1,-1) means no hover.
@@ -138,8 +177,15 @@ Item {
             glass._mouseV = -1
         }
     }
+    // A widget's position can change without any signal we can bind to (an
+    // ancestor moves, the containment relayouts), so the offset has to be
+    // polled. But it only changes while something is being dragged, and a
+    // desktop widget sits still for days at a time -- polling mapToItem at
+    // 60 Hz forever to learn that nothing moved is the expensive way to
+    // find out. Poll slowly at rest, and drop to frame rate for a second
+    // after a move is seen so a drag still tracks smoothly.
     Timer {
-        interval: 16
+        interval: glass._dirtyBurst ? 16 : 500
         repeat: true
         // Solid mode doesn't need geometry updates (no wallpaper sample),
         // but we still want the timer disabled until the widget has size.
@@ -245,7 +291,7 @@ Item {
         anchors.fill: parent
         opacity: 0
         sourceItem: glass._blurActive ? cropPass : null
-        live: glass._blurActive
+        live: glass._chainLive
         hideSource: true
         smooth: true
     }
@@ -262,7 +308,7 @@ Item {
     ShaderEffectSource {
         id: down1Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 1 ? down1 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: Qt.size(Math.max(1, Math.round(glass._widgetW / 2)),
                              Math.max(1, Math.round(glass._widgetH / 2)))
     }
@@ -278,7 +324,7 @@ Item {
     ShaderEffectSource {
         id: down2Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 2 ? down2 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: Qt.size(Math.max(1, Math.round(glass._widgetW / 4)),
                              Math.max(1, Math.round(glass._widgetH / 4)))
     }
@@ -294,7 +340,7 @@ Item {
     ShaderEffectSource {
         id: down3Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 3 ? down3 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: Qt.size(Math.max(1, Math.round(glass._widgetW / 8)),
                              Math.max(1, Math.round(glass._widgetH / 8)))
     }
@@ -310,7 +356,7 @@ Item {
     ShaderEffectSource {
         id: down4Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 4 ? down4 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: Qt.size(Math.max(1, Math.round(glass._widgetW / 16)),
                              Math.max(1, Math.round(glass._widgetH / 16)))
     }
@@ -326,7 +372,7 @@ Item {
     ShaderEffectSource {
         id: down5Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 5 ? down5 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: Qt.size(Math.max(1, Math.round(glass._widgetW / 32)),
                              Math.max(1, Math.round(glass._widgetH / 32)))
     }
@@ -342,7 +388,7 @@ Item {
     ShaderEffectSource {
         id: down6Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 6 ? down6 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: Qt.size(Math.max(1, Math.round(glass._widgetW / 64)),
                              Math.max(1, Math.round(glass._widgetH / 64)))
     }
@@ -367,7 +413,7 @@ Item {
     ShaderEffectSource {
         id: up6Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 6 ? up6 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: down5Tex.textureSize
     }
 
@@ -382,7 +428,7 @@ Item {
     ShaderEffectSource {
         id: up5Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 5 ? up5 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: down4Tex.textureSize
     }
 
@@ -397,7 +443,7 @@ Item {
     ShaderEffectSource {
         id: up4Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 4 ? up4 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: down3Tex.textureSize
     }
 
@@ -412,7 +458,7 @@ Item {
     ShaderEffectSource {
         id: up3Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 3 ? up3 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: down2Tex.textureSize
     }
 
@@ -427,7 +473,7 @@ Item {
     ShaderEffectSource {
         id: up2Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive && glass._blurIters >= 2 ? up2 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: down1Tex.textureSize
     }
 
@@ -441,7 +487,7 @@ Item {
     ShaderEffectSource {
         id: up1Tex; anchors.fill: parent; opacity: 0
         sourceItem: glass._blurActive ? up1 : null
-        live: glass._blurActive; hideSource: true; smooth: true
+        live: glass._chainLive; hideSource: true; smooth: true
         textureSize: Qt.size(Math.round(glass._widgetW), Math.round(glass._widgetH))
     }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,9 @@ Pipeline:
 3. Fallback `Rectangle` renders a flat tinted rounded rect when `wallpaperItem` is null (panels, plasmoidviewer). `glass.active` toggles between the two.
 
 Important nuances:
-- **`realtimeRefraction: false` by default.** `wallpaperTex.live` binds to this. The `updateGeometry()` Timer (16ms) calls `wallpaperTex.scheduleUpdate()` when the widget moves and the width/height Connections do the same on resize — so static wallpapers only re-capture on actual geometry change. Turn the config on only for animated/video wallpapers.
+- **`realtimeRefraction: false` by default.** `wallpaperTex.live` binds to this, so static wallpapers only re-capture on actual geometry change. Turn the config on only for animated/video wallpapers.
+- **The blur chain is gated, not continuously live.** The crop + Kawase pyramid is a chain of `ShaderEffectSource`s feeding one another; if every link is `live` the scene graph never reaches a resting state (each link dirties the next) and Plasma re-blurs the wallpaper at full framerate forever. Instead every link binds `live: glass._chainLive`, which is true only in realtime mode or during a short `_dirtyBurst`. Anything that can change a pixel calls `markDirty()`; `settleTimer` (250ms) ends the burst. **When you add a property that affects the blur output, add a `markDirty()` call for it** — otherwise the change renders late or not at all.
+- **`updateGeometry()` polls `mapToItem` at 500ms at rest, 16ms during a burst.** A widget's position can change with no signal to bind to (ancestor moves, containment relayout), so it has to be polled — but only a drag changes it, and a move detected by the poll calls `markDirty()`, which raises the poll to frame rate for the length of the burst.
 - **Mouse hover state** is plumbed into the shader via `mousePos` (widget UV) and `mouseFade` (0..1 with 180ms Behavior) — currently used by the corner-specular effect only.
 - **Shader uniforms** mirror QML properties 1:1 via the `ShaderEffect { property real ...; }` block. Adding a uniform means: add the QML property on `glass`, add it on `glassShader`, add it to the shader's `uniform buf { }`, rebuild shaders.
 


### PR DESCRIPTION
Fixes the continuous full-framerate redraw behind #17 and #23.

## The problem

`1-common/components/LiquidGlass.qml` builds the backdrop from a crop pass plus a 12-stage Dual Kawase pyramid — 13 `ShaderEffectSource`s, each feeding the next. Every one of them was unconditionally `live: glass._blurActive`.

Chained live sources dirty each other every frame, so the scene graph never reaches a resting state. Plasma re-blurs the wallpaper at full framerate for as long as a widget exists — even on a static wallpaper, where every frame is byte-identical to the one before it.

The intent was already in the file. `realtimeRefraction` defaults to `false` and is documented as "the wallpaper is only re-captured on geometry changes (recommended for static wallpapers — saves GPU per frame)". But it was only wired into `wallpaperTex.live`; the 13 downstream sources ignored it, so the flag was doing about a fourteenth of its job.

## The fix

Gate the chain on a new `_chainLive` instead of `_blurActive`:

```qml
readonly property bool _chainLive: glass._blurActive
                                   && (glass.realtimeRefraction || glass._dirtyBurst)
```

`markDirty()` opens a 250 ms burst, and `settleTimer` closes it. It's called from everything that can actually change a pixel: resize, move, `blurRadius`, `solidMode`, `wallpaperItem`, `realtimeRefraction`, and `active`. Realtime mode is untouched and still runs live every frame.

The burst is deliberately several frames rather than one `scheduleUpdate()` per link — the pyramid settles one stage per frame, and a burst lets it flush through without having to hand-order 13 updates in dependency order.

Second change: the `updateGeometry()` poll drops from 16 ms to 500 ms at rest. It exists to notice moves that emit no bindable signal (an ancestor moves, the containment relayouts), but a desktop widget sits still for days. A move detected by the poll calls `markDirty()`, which raises the poll back to frame rate for the length of the burst, so dragging still tracks smoothly.

## Measurements

Plasma 6.7.4 on Wayland, calendar widget on the desktop, static `org.kde.image` wallpaper, default config (`styleMode=0` glass, `blurRadiusPx=6`, `realtimeRefraction=false`). Sampled `utime` from `/proc/<pid>/stat` over 25–45 s windows:

| | plasmashell CPU | plasmashell RSS |
|---|---|---|
| before | **97% of a core**, sustained, never idling | 6.2 GB after 6 days uptime |
| after | **5.7% of a core**, steady | 608 MB, flat |

For scale, the systemd scope holding the old process had consumed **6d 7h 23m of CPU over ~7 days of wall clock**. The practical symptom was a ~4 s delay opening Kickoff, because Kickoff is built and painted on plasmashell's main thread and that thread was already saturated.

Same measurement method both times, so it's like-for-like rather than a cold-start artefact.

## Notes

- Visual output is unchanged — it just stops recomputing an identical image 60 times a second.
- `qmllint` is clean, and no new QML warnings appear in the journal.
- `_blurActive` has no unambiguously-spelled change handler (the leading underscore), so the burst hooks its three inputs instead. Noted in a comment.
- `AGENTS.md` is updated: the LiquidGlass nuances section described the old timer behaviour, and now documents the gating plus the rule that a new blur-affecting property needs a `markDirty()`.
- This might also help #20 (static wallpaper switch not picked up without realtime refraction) — `markDirty()` fires on `wallpaperItem` change — but I haven't verified that case, so I'm not claiming it.

Only `1-common/components/LiquidGlass.qml` changes, so all 15 packages pick it up through their symlinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK75VSh3VAsyoTUomwjiZu
